### PR TITLE
Ensure we use a valid AR.

### DIFF
--- a/ota-server/Makefile
+++ b/ota-server/Makefile
@@ -1,5 +1,6 @@
 CC = xtensa-lx106-elf-gcc
 LD = xtensa-lx106-elf-ld
+AR = xtensa-lx106-elf-ar
 ESP_SDK = $(shell $(CC) -print-sysroot)/usr
 CFLAGS = -std=gnu99 -Os -I. -mtext-section-literals -mlongcalls -mforce-l32 -ffunction-sections -fdata-sections -DLWIP_OPEN_SRC -D__ets__
 LDLIBS = -L$(ESP_SDK)/lib -L. -laxtls -lmain -lnet80211 -lwpa -llwip_open -lpp -lphy -lnet80211 -lgcc


### PR DESCRIPTION
I had some build problems related to axtls: it seems the `ar` command that was being used was not from the cross compiler.

This was causing errors on the linking step where the names were not found in the `libaxtls.a` file.

This forces it to use the cross compiler, and fixes those errors.