### PR TITLE
Prevent warning/error about not fitting in RAM.

### DIFF
--- a/boot8266/boot8266.ld
+++ b/boot8266/boot8266.ld
@@ -158,6 +158,12 @@ SECTIONS
     *libmbedtls.a:(.literal .text .literal.* .text.*)
 
     *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text)
+
+    *libcrypto.a:(.literal.* .text.*)
+    *libnet80211.a:(.literal.* .text.*)
+    *libwpa.a:(.literal.* .text.*)
+    *libwpa2.a:(.literal.* .text.*)
+
     _irom0_text_end = ABSOLUTE(.);
   } >irom0_0_seg :irom0_0_phdr
 

--- a/ota-server/ota.ld
+++ b/ota-server/ota.ld
@@ -161,6 +161,12 @@ SECTIONS
     /*ota.o(.literal*, .text*)*/
 
     *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text)
+
+    *libcrypto.a:(.literal.* .text.*)
+    *libnet80211.a:(.literal.* .text.*)
+    *libwpa.a:(.literal.* .text.*)
+    *libwpa2.a:(.literal.* .text.*)
+
     _irom0_text_end = ABSOLUTE(.);
   } >irom0_0_seg :irom0_0_phdr
 


### PR DESCRIPTION
This is based on https://github.com/micropython/micropython/commit/964bf935a39498e7224657787b0be277279d2bae

It resolves #19 